### PR TITLE
[FIX] base_preload_compare: add access rules to model

### DIFF
--- a/base_preload_compare/__manifest__.py
+++ b/base_preload_compare/__manifest__.py
@@ -15,6 +15,8 @@
         'base',
     ],
     'data': [
+        'security/ir.model.access.csv',
+
         'views/data_preload.xml',
         'data/menu.xml',
     ],

--- a/base_preload_compare/security/ir.model.access.csv
+++ b/base_preload_compare/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_base_preload_compare_user,access_base_preload_compare_user,model_base_preload_compare,base.group_user,1,0,0,0
+access_base_preload_compare_admin,access_base_preload_compare_admin,model_base_preload_compare,base.group_system,1,1,1,1


### PR DESCRIPTION
* users are allowed to read (if they don't have read access they can't use the standard odoo import)
* admins have full access